### PR TITLE
Standalone incompatibility fix

### DIFF
--- a/SyliusTranslationBundle.php
+++ b/SyliusTranslationBundle.php
@@ -19,7 +19,7 @@ class SyliusTranslationBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,


### PR DESCRIPTION
Fixes an error when installed standalone:

Cannot make non static method Sylius\Bundle\ResourceBundle\ResourceBundleInterface::getSupportedDrivers() static in class Sylius\Bundle\TranslationBundle\SyliusTranslationBundle
